### PR TITLE
feat: add a facade exposing data required to build collections hierarchies

### DIFF
--- a/app/api/collection/facade.py
+++ b/app/api/collection/facade.py
@@ -150,3 +150,13 @@ class CollectionFacade(JSONAPIAbstractChangeloggedFacade):
                 if data["payload"]["id"] != self.id and data["payload"]["type"] != self.TYPE:
                     data["payload"]["collections"] = [l for l in data["payload"]["collections"] if l.get("id") != self.id]
                     SearchIndexManager.add_to_index(index=data["index"], id=data["id"], payload=data["payload"])
+
+
+class CollectionHierarchyOnlyFacade(CollectionFacade):
+    def __init__(self, *args, **kwargs):
+        super(CollectionHierarchyOnlyFacade, self).__init__(*args, **kwargs)
+        self.relationships = {
+            "admin": self.relationships['admin'],
+            "parents": self.relationships["parents"],
+            "children": self.relationships["children"]
+        }

--- a/app/api/facade_manager.py
+++ b/app/api/facade_manager.py
@@ -1,5 +1,5 @@
 from app.api.changelog.facade import ChangelogFacade
-from app.api.collection.facade import CollectionFacade
+from app.api.collection.facade import CollectionFacade, CollectionHierarchyOnlyFacade
 from app.api.person.facade import PersonFacade
 from app.api.person_has_role.facade import PersonHasRoleFacade
 from app.api.person_role.facade import PersonRoleFacade
@@ -32,6 +32,7 @@ _FACADES = {
     Collection.__tablename__: {
         "default": CollectionFacade,
         "search": CollectionFacade,
+        "hierarchy": CollectionHierarchyOnlyFacade,
     },
     Person.__tablename__: {
         "default": PersonFacade,


### PR DESCRIPTION
The only exposed relationships are `parent`, `children` and `admin`. This avoids adding to much overhead when loading all collections.