### PR TITLE
fix: "GET /languages" request not being handled correctly by flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,6 @@ requests==2.27.1
 six==1.16.0
 SQLAlchemy==1.4.0
 urllib3==1.26.9
-Werkzeug==2.1.1
+Werkzeug>=2.3,<3
 WTForms==3.0.1
 zipp==3.8.0


### PR DESCRIPTION
It seems that the werkzeug version we used had could have a bug when building wsgi requests to be handled by flask when in multi-thread mode :

After removing a witness, when the document was reloaded the `GET` request to the `/languages` route was transformed by werkzeug which replaced the GET method by `{somejsonfrompreviousrequest}GET`.

Using other wsgi servers, adding threaded=False to flask_app.oy or upgrading werkzeug seem to fix the problem.

Closes https://github.com/chartes/lettres-vue/issues/115